### PR TITLE
update deployment selectors to match app label

### DIFF
--- a/manifests/cron-deployment.yaml
+++ b/manifests/cron-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: sentry-cron
+      app: sentry
   replicas: 1
   template:
     metadata:

--- a/manifests/worker-deployment.yaml
+++ b/manifests/worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: sentry-worker
+      app: sentry
   replicas: 2
   template:
     metadata:


### PR DESCRIPTION
The current sample yaml throws the following errors when we try to apply it to a cluster:

```
Error from server (Invalid): error when creating "STDIN": Deployment.apps "sentry-cron" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"sentry", "role":"cron"}: `selector` does not match template `labels`
Error from server (Invalid): error when creating "STDIN": Deployment.apps "sentry-worker" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"sentry", "role":"worker"}: `selector` does not match template `labels`
```
This PR updates it with appropriate labels