### PR TITLE
Preflight Analyzers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
    branches:
-     - master
+     - unstable
 
 jobs:
   create-unstable-release:

--- a/manifests/application.yaml
+++ b/manifests/application.yaml
@@ -12,6 +12,9 @@ spec:
   componentKinds:
     - group: core
       kind: Service
+    # I have no idea what I'm doing here.
+    - group: core
+      kind: Ingress
     - group: apps
       kind: Deployment
     - group: apps

--- a/manifests/config.yaml
+++ b/manifests/config.yaml
@@ -32,8 +32,21 @@ spec:
           items:
             - name: embedded_postgres
               title: Embedded Postgres
-            - name: external_postgres
-              title: External Postgres
+            - name: external_postgres_inline
+              title: External Postgres Inline
+            - name: external_postgres_secret
+              title: External Postgres From Secret
         - name: embedded_postgres_password
+          hidden: true
           type: password
           value: "{{repl RandomString 32}}"
+        - name: external_postgres_connectionstring
+          title: Postgres Connection string
+          when: '{{repl ConfigOptionEquals "postgres_type" "external_postgres_inline"}}'
+          type: text
+          default: postgresql://user:pass@host/db
+        - name: external_postgres_secretname
+          title: Postgres Secret Name
+          help_text: Enter the name of a secret containing the key `PG_CONNSTRING`
+          when: '{{repl ConfigOptionEquals "postgres_type" "external_postgres_secret"}}'
+          type: text

--- a/manifests/preflight.yaml
+++ b/manifests/preflight.yaml
@@ -4,6 +4,50 @@ metadata:
   name: sentry-enterprise
 spec:
   analyzers:
+    # Fails on preflight page even though registry has been added vendor.replicated.com.
+    - imagePullSecret:
+          checkName: Has Access to index.docker.io
+          registryName: index.docker.io
+          outcomes:
+            - fail:
+                message: Cannot pull from index.docker.io
+            - pass:
+                message: Found credentials to pull from index.docker.io
+    # Fails on preflight page even though Ingress exists.
+    - ingress:
+        namespace: default
+        ingressName: sentry-ingress
+        outcomes:
+          - fail:
+              message: Sentry ingress is not working.
+          - pass:
+              message: Sentry ingress is working.
+    - deploymentStatus:
+        name: sentry-worker
+        namespace: default
+        outcomes:
+          - fail:
+              when: "< 1"
+              message: The Sentry Worker deployment does not have any ready replicas.
+          - warn:
+              when: "= 1"
+              message: The Sentry Worker deployment has only a single ready replica.
+          - pass:
+              message: There are multiple replicas of the Sentry Worker deployment ready.
+    # Is it statefulset or statefulsetStatus?
+    # Does not even show up in preflights page.
+    - statefulsetStatus:
+        name: sentry-redis-master
+        namespace: default
+        outcomes:
+          - fail:
+              when: "< 1"
+              message: The API deployment does not have any ready replicas.
+          - warn:
+              when: "= 1"
+              message: The API deployment has only a single ready replica.
+          - pass:
+              message: There are multiple replicas of the API deployment ready.
     - clusterVersion:
         outcomes:
           - fail:
@@ -18,10 +62,63 @@ spec:
               when: ">= 1.15.0"
               message: Your cluster meets the recommended and required versions of Kubernetes.
     - customResourceDefinition:
-        customResourceDefinitionName: deployment
+        customResourceDefinitionName: ingressroutes.contour.heptio.com
         outcomes:
           - fail:
-              message: Kind deployment not found!
+              message: IngressRoutes CRD not found!
           - pass:
-              message: Deployment kind found!
-
+              message: IngressRoutes CRD found!
+    - containerRuntime:
+        outcomes:
+          - pass:
+              when: "== docker"
+              message: Docker container runtime was found.
+          - fail:
+              message: Did not find Docker container runtime.
+    - storageClass:
+        checkName: Required storage classes
+        storageClassName: "default"
+        outcomes:
+          - fail:
+              message: Could not find a storage class called default.
+          - pass:
+              message: All good on storage classes
+    # Does not even show up in preflights page.
+    - secret:
+        checkName: Sentry Postgresql
+        secretName: sentry-postgresql
+        namespace: default
+        key: postgres-password
+        outcomes:
+          - fail:
+              message: The `sentry-postgresql` secret was not found or the `postgres-password` key was not detected.
+          - pass:
+              message: The Postgres Password was found in a secret in the cluster.
+    - distribution:
+        outcomes:
+          - fail:
+              when: "== docker-desktop"
+              message: The application does not support Docker Desktop Clusters
+          - fail:
+              when: "== microk8s"
+              message: The application does not support Microk8s Clusters
+          - fail:
+              when: "== minikube"
+              message: The application does not support Minikube Clusters
+          - pass:
+              when: "== eks"
+              message: EKS is a supported distribution
+          - pass:
+              when: "== gke"
+              message: GKE is a supported distribution
+          - pass:
+              when: "== aks"
+              message: AKS is a supported distribution
+          - pass:
+              when: "== kurl"
+              message: KURL is a supported distribution
+          - pass:
+              when: "== digitalocean"
+              message: DigitalOcean is a supported distribution
+          - warn:
+              message: Unable to determine the distribution of Kubernetes

--- a/manifests/sentry-ingress.yaml
+++ b/manifests/sentry-ingress.yaml
@@ -1,0 +1,12 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: sentry-ingress
+spec:
+  rules:
+  - http:
+      paths:
+        - path: /
+          backend:
+            serviceName: sentry
+            servicePort: 9000


### PR DESCRIPTION
Tried to implement all the available analyzers and this is the progress so far:

https://troubleshoot.sh/reference/analyzers/overview/

* clusterVersion: Setup previously, works as expected.
* imagePullSecret: The docs are incorrect, they have a secret example rather than imagePullSecrets but I found the format elsewhere. Regardless still fails. I added the registry to Images section in vendor.replicated.com, is there anything else I need to do? https://troubleshoot.sh/reference/analyzers/image-pull-secrets/
* secret: Does not even show up in preflights, not sure whats up?
* ingress: Added an ingress for Sentry, but still fails.
* customResourceDefinition: It was failing before because Deployment is not a CRD apparently. So I updated it to something that I knew for a fact is a CRD and now the preflight works.
* storageClass: Setup previously, works as expected.
* deploymentStatus: Added a check for sentry worker deployment and tested `when` as well and it shows the check passing.
* statefulset: Is it statefulset or statefulsetStatus? The source and docs do not match it seems? Anyway, I tried both and the preflight check does not even show up.
Source: https://github.com/replicatedhq/troubleshoot/blob/master/pkg/apis/troubleshoot/v1beta1/analyzer_shared.go#L89
Docs: https://troubleshoot.sh/reference/analyzers/statefulset-status/
* containerRuntime: Setup previously, works as expected.
* distribution: Check works but it's not able to detect the distribution for embedded, is it kurl? or the os name or something else?

<img width="1205" alt="Screen Shot 2019-12-02 at 7 07 25 PM" src="https://user-images.githubusercontent.com/6979073/70005297-105aeb80-1537-11ea-8b46-d3c472803c41.png">
