### PR TITLE
Simplify quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,37 @@
 # Kots Sentry Demo
 
 
-This is a working demo for packaging Sentry as a Kots application.
+This is a working demo for packaging Sentry as a Kots application. 
 
-## Quick Start
 
-1. Create a new Kots application in the [Replicated Vendor Portal](https://vendor.replicated.com)
+## Installing the example
 
-* Create a new application and name it (by default this is a KOTS application, other schedulers are available if needed).
-* Select the 'Releases' tab of the vendor portal, click "create release," delete the default yaml files and upload all the files from the `manifests` directory of this repo.  These files include plain Kubernetes yaml for sample app (Sentry), along with the following Kots-specific yaml specs:
+There is a license file in this repo that can be used to install Sentry with KOTS from the perspective on an end user. For an existing cluster install, simple point `kubectl` at your cluster, then follow the steps:
 
-    * replicated-app.yaml - specifies application title and icon, for display in the kots admin console
-    * preflight.yaml - specifies tests to run against the target cluster, prior to deployment of the app
-    * support-bundle.yaml - specifies how custom diagnostic info should be collected, analyzed, and displayed
-    * application.yaml - specifies the application link URLs (from the Kubernetes App SIG: https://github.com/kubernetes-sigs/application)
-    * config.yaml - specifies the configuration options in the Replicated config DSL.
-
-* Create a release, and promote that release to a deployment channel
-
-2. Create a customer and download an application license
-
-* Select the Customers option on the left menu, create a new customer, and assign the customer to a channel.
-* Select the Channels option from the left menu, and review the 'Install' command, which will show `your-app-slug` and a Replicated URL to install with Kots.
-
-3. Install the Kots kubectl plugin on your workstation
+1. Install the `kots` plugin:
 
 ```shell
-curl https://kots.io/install | bash
+curl -fsSL https://kots.io/install | bash
 ```
 
-4. Test the deployment:
-
-* Choose `your-namespace` which will be the namespace for every component of the deployed application and the kots admin console
+2. Run `kubectl kots install` from your workstation:
 
 ```shell
-kubectl kots install your-app-slug
+kubectl kots install sentry-pro
 ```
-* You will be prompted to provide a namespace to install into as well as a password (to control access to the admin console), and then to connect to http://localhost:8800 , where you can login with the password you just specified, and then upload the customer license.
 
-5. Clean up
+You'll be walked through a few questions as kots sets up the cluster. Once the UI is launched on `localhost:8800`, you can proceed to configure the instance. Again, you can use [the license file in this repo](./KOTS-license-example-sentry-pro.yaml) to install the instance.
+
+
+3. Clean up
+
+When you're done, you can clean up by deleting the namespace you selected during installation.
 
 ```shell
 kubectl delete ns your-namespace
 ```
+
+## Packaging your own app
+
+To get started developing your own version of Sentry (or any Kubernetes app) on KOTS, check out the [quickstart guide](https://kots.io/vendor/guides/quickstart)
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a working demo for packaging Sentry as a Kots application.
 
 ## Installing the example
 
-There is a license file in this repo that can be used to install Sentry with KOTS from the perspective on an end user. For an existing cluster install, simple point `kubectl` at your cluster, then follow the steps:
+There is a license file in this repo that can be used to install Sentry with KOTS from the perspective of an end user. For an existing cluster install, simply point `kubectl` at your cluster, then follow the steps:
 
 1. Install the `kots` plugin:
 


### PR DESCRIPTION
This guide pre-dates https://kots.io the website, so it's been updated to focus on

1. Installing sentry using the license in this repo
2. Linking out to the full Quickstart guide as a next step