### PR TITLE
Removed the need for wget since this is not a default binary for Mac …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ deps-vendor-cli:
 	  echo '-> Downloading Replicated CLI to ./deps '; \
 	  mkdir -p deps/; \
 	  curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
-	  | grep "browser_download_url.*darwin_amd64.tar.gz" \
+	  | grep "browser_download_url.*$(dist)_amd64.tar.gz" \
 	  | cut -d : -f 2,3 \
 	  | tr -d \" \
 	  | xargs curl -L \

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ deps-vendor-cli:
 	  echo '-> Downloading Replicated CLI to ./deps '; \
 	  mkdir -p deps/; \
 	  curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
-	  | grep "browser_download_url.*$(dist)_amd64.tar.gz" \
+	  | grep "browser_download_url.*darwin_amd64.tar.gz" \
 	  | cut -d : -f 2,3 \
 	  | tr -d \" \
-	  | wget -O- -qi - \
+	  | xargs curl -L \
 	  | tar xvz -C deps; \
 	fi
 


### PR DESCRIPTION
Since cURL is the default for most systems, I replaced the extra wget functionality with a cURL command for efficiency. This might prevent either: some systems from having to install wget, or some systems from breaking because wget is not installed.